### PR TITLE
fixed transaction value bytes for serialization

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.elrond</groupId>
     <artifactId>erdjava</artifactId>
-    <version>1.0.1</version>
+    <version>1.0.2</version>
 
     <name>erdjava</name>
     <description>The Java 1.8 SDK for interacting with the Elrond blockchain</description>

--- a/src/main/java/elrond/BigIntegerCodec.java
+++ b/src/main/java/elrond/BigIntegerCodec.java
@@ -1,0 +1,27 @@
+package elrond;
+
+import com.google.protobuf.ByteString;
+
+import java.math.BigInteger;
+
+public class BigIntegerCodec {
+    public static ByteString serializeValue(BigInteger value) {
+        if (value == null) {
+            return ByteString.copyFrom("".getBytes());
+        }
+
+        byte[] valueBytes = value.toByteArray();
+        boolean isFirstByteForTheSign = valueBytes[0] == (byte) 0;
+        boolean isZero = value.intValue() == 0;
+
+        if (!isFirstByteForTheSign || isZero) {
+            byte[] bytes = new byte[valueBytes.length + 1];
+            bytes[0] = 0; // positive sign expected on the elrond-go side
+
+            System.arraycopy(valueBytes, 0, bytes, 1, valueBytes.length);
+            return ByteString.copyFrom(bytes);
+        }
+
+        return ByteString.copyFrom(valueBytes);
+    }
+}

--- a/src/main/java/elrond/Transaction.java
+++ b/src/main/java/elrond/Transaction.java
@@ -96,12 +96,13 @@ public class Transaction {
 
     /**
      * Computes transaction hash without broadcasting it to blockchain
+     *
      * @return returns the hash of the transaction after serializing it into proto and applying the blake2b hasher
      */
     public String computeHash() {
         TransactionOuterClass.Transaction.Builder builder = TransactionOuterClass.Transaction.newBuilder()
                 .setNonce(this.getNonce())
-                .setValue(this.serializeValue())
+                .setValue(BigIntegerCodec.serializeValue(this.value))
                 .setRcvAddr(ByteString.copyFrom(this.getReceiver().pubkey()))
                 .setSndAddr(ByteString.copyFrom(this.getSender().pubkey()))
                 .setGasPrice(this.getGasPrice())
@@ -126,26 +127,6 @@ public class Transaction {
 
         this.txHash = new String(Hex.encode(out));
         return this.txHash;
-    }
-
-    public ByteString serializeValue() {
-        if(this.value == null) {
-            return ByteString.copyFrom("".getBytes());
-        }
-
-        byte[] valueBytes = value.toByteArray();
-        boolean isFirstByteForTheSign = valueBytes[0] == (byte) 0;
-        boolean isZero = value.intValue() == 0;
-
-        if (!isFirstByteForTheSign || isZero) {
-            byte[] bytes = new byte[valueBytes.length + 1];
-            bytes[0] = 0; // positive sign expected on the elrond-go side
-
-            System.arraycopy(valueBytes, 0, bytes, 1, valueBytes.length);
-            return ByteString.copyFrom(bytes);
-        }
-
-        return ByteString.copyFrom(valueBytes);
     }
 
     public void setNonce(long nonce) {

--- a/src/main/java/elrond/Transaction.java
+++ b/src/main/java/elrond/Transaction.java
@@ -102,7 +102,7 @@ public class Transaction {
     public String computeHash() {
         TransactionOuterClass.Transaction.Builder builder = TransactionOuterClass.Transaction.newBuilder()
                 .setNonce(this.getNonce())
-                .setValue(BigIntegerCodec.serializeValue(this.value))
+                .setValue(BigIntegerCodec.serializeValue(this.getValue()))
                 .setRcvAddr(ByteString.copyFrom(this.getReceiver().pubkey()))
                 .setSndAddr(ByteString.copyFrom(this.getSender().pubkey()))
                 .setGasPrice(this.getGasPrice())
@@ -139,6 +139,10 @@ public class Transaction {
 
     public void setValue(BigInteger value) {
         this.value = value;
+    }
+
+    public BigInteger getValue() {
+        return value;
     }
 
     public void setSender(Address sender) {

--- a/src/test/java/elrond/BigIntegerCodecTest.java
+++ b/src/test/java/elrond/BigIntegerCodecTest.java
@@ -1,0 +1,67 @@
+package elrond;
+
+import com.google.protobuf.ByteString;
+import org.apache.commons.codec.binary.Hex;
+import org.junit.Test;
+
+import java.math.BigInteger;
+import java.util.Arrays;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+
+public class BigIntegerCodecTest {
+    static class TxValueBytesPair {
+        String input;
+        String expected;
+
+        public TxValueBytesPair(String input, String expected) {
+            this.input = input;
+            this.expected = expected;
+        }
+    }
+
+    @Test
+    public void TestTxBytesValue() {
+        List<TxValueBytesPair> pairs = Arrays.asList(
+                new TxValueBytesPair("", ""),
+                new TxValueBytesPair("0", "0000"),
+                new TxValueBytesPair("10", "000a"),
+                new TxValueBytesPair("100", "0064"),
+                new TxValueBytesPair("1000", "0003e8"),
+                new TxValueBytesPair("1500", "0005dc"),
+                new TxValueBytesPair("1505", "0005e1"),
+                new TxValueBytesPair("1793", "000701"),
+                new TxValueBytesPair("1000000000000000000", "000de0b6b3a7640000"),
+                new TxValueBytesPair("1000000000000000001", "000de0b6b3a7640001"),
+                new TxValueBytesPair("1000000000000000000", "000de0b6b3a7640000"),
+                new TxValueBytesPair("1799999999999990000", "0018fae27693b3d8f0"),
+                new TxValueBytesPair("11485000000000000000", "009f62eaa65d5c8000"),
+                new TxValueBytesPair("15940000000000000000", "00dd36418bd7ba0000"),
+                new TxValueBytesPair("15500159000000000000000000", "000cd2494d96e1f8369c0000"),
+                new TxValueBytesPair("15500159777799995555333311", "000cd24958622ef1cffc44bf"),
+                new TxValueBytesPair("77993311779933110000000000", "004083b9e74f854654399c00"),
+                new TxValueBytesPair("77993311779933117799331177", "004083b9e74f85482519f569"));
+
+        for (TxValueBytesPair pair : pairs) {
+            assertBytesValue(pair);
+        }
+    }
+
+    public void assertBytesValue(TxValueBytesPair pair) {
+        // arrange
+        BigInteger value;
+        if ("".equals(pair.input)) {
+            value = null;
+        } else {
+            value = new BigInteger(pair.input);
+        }
+
+        // act
+        ByteString res = BigIntegerCodec.serializeValue(value);
+        String hexBI = Hex.encodeHexString(res.toByteArray());
+
+        // assert
+        assertEquals(pair.expected, hexBI);
+    }
+}

--- a/src/test/java/elrond/ProxyProviderTest.java
+++ b/src/test/java/elrond/ProxyProviderTest.java
@@ -1,14 +1,14 @@
 package elrond;
 
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+import org.junit.Test;
+
 import java.io.IOException;
 import java.math.BigInteger;
 
-import okhttp3.mockwebserver.MockResponse;
-import okhttp3.mockwebserver.MockWebServer;
-import org.junit.Ignore;
-import org.junit.Test;
-
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
 
 public class ProxyProviderTest {
     private final Address testAddress = Address.fromBech32("erd1l453hd0gt5gzdp7czpuall8ggt2dcv5zwmfdf3sd3lguxseux2fsmsgldz");

--- a/src/test/java/elrond/TransactionTest.java
+++ b/src/test/java/elrond/TransactionTest.java
@@ -90,59 +90,12 @@ public class TransactionTest {
         transaction.sign(wallet);
 
         assertEquals("eb000037b70dfe3d89abc50214b3ce0c4afbfe66f2b636834d46e33af690f3d0", transaction.computeHash());
-    }
 
-    static class TxValueBytesPair {
-        String input;
-        String expected;
+        // With data field
+        transaction.setData("test data");
 
-        public TxValueBytesPair(String input, String expected) {
-            this.input = input;
-            this.expected = expected;
-        }
-    }
+        transaction.sign(wallet);
 
-    @Test
-    public void TestTxBytesValue() {
-        List<TxValueBytesPair> pairs = Arrays.asList(
-                new TxValueBytesPair("", ""),
-                new TxValueBytesPair("0", "0000"),
-                new TxValueBytesPair("10", "000a"),
-                new TxValueBytesPair("100", "0064"),
-                new TxValueBytesPair("1000", "0003e8"),
-                new TxValueBytesPair("1500", "0005dc"),
-                new TxValueBytesPair("1505", "0005e1"),
-                new TxValueBytesPair("1793", "000701"),
-                new TxValueBytesPair("1000000000000000000", "000de0b6b3a7640000"),
-                new TxValueBytesPair("1000000000000000001", "000de0b6b3a7640001"),
-                new TxValueBytesPair("1000000000000000000", "000de0b6b3a7640000"),
-                new TxValueBytesPair("1799999999999990000", "0018fae27693b3d8f0"),
-                new TxValueBytesPair("11485000000000000000", "009f62eaa65d5c8000"),
-                new TxValueBytesPair("15940000000000000000", "00dd36418bd7ba0000"),
-                new TxValueBytesPair("15500159000000000000000000", "000cd2494d96e1f8369c0000"),
-                new TxValueBytesPair("15500159777799995555333311", "000cd24958622ef1cffc44bf"),
-                new TxValueBytesPair("77993311779933110000000000", "004083b9e74f854654399c00"),
-                new TxValueBytesPair("77993311779933117799331177", "004083b9e74f85482519f569"));
-
-        for (TxValueBytesPair pair : pairs) {
-            assertBytesValue(pair);
-        }
-    }
-
-    public void assertBytesValue(TxValueBytesPair pair) {
-        // arrange
-        Transaction tx = new Transaction();
-        if ("".equals(pair.input)) {
-            tx.setValue(null);
-        } else {
-            tx.setValue(new BigInteger(pair.input));
-        }
-
-        // act
-        ByteString res = tx.serializeValue();
-        String hexBI = Hex.encodeHexString(res.toByteArray());
-
-        // assert
-        assertEquals(pair.expected, hexBI);
+        assertEquals("3fb8406c408fbdd9b01ce8c8a0dcbb1a382cba713a132f40d552ec8db63c89a5", transaction.computeHash());
     }
 }

--- a/src/test/java/elrond/TransactionTest.java
+++ b/src/test/java/elrond/TransactionTest.java
@@ -1,7 +1,12 @@
 package elrond;
 
+import com.google.protobuf.ByteString;
+import org.apache.commons.codec.binary.Hex;
 import org.junit.Test;
+
 import java.math.BigInteger;
+import java.util.Arrays;
+import java.util.List;
 
 import static org.junit.Assert.assertEquals;
 
@@ -85,5 +90,59 @@ public class TransactionTest {
         transaction.sign(wallet);
 
         assertEquals("eb000037b70dfe3d89abc50214b3ce0c4afbfe66f2b636834d46e33af690f3d0", transaction.computeHash());
+    }
+
+    static class TxValueBytesPair {
+        String input;
+        String expected;
+
+        public TxValueBytesPair(String input, String expected) {
+            this.input = input;
+            this.expected = expected;
+        }
+    }
+
+    @Test
+    public void TestTxBytesValue() {
+        List<TxValueBytesPair> pairs = Arrays.asList(
+                new TxValueBytesPair("", ""),
+                new TxValueBytesPair("0", "0000"),
+                new TxValueBytesPair("10", "000a"),
+                new TxValueBytesPair("100", "0064"),
+                new TxValueBytesPair("1000", "0003e8"),
+                new TxValueBytesPair("1500", "0005dc"),
+                new TxValueBytesPair("1505", "0005e1"),
+                new TxValueBytesPair("1793", "000701"),
+                new TxValueBytesPair("1000000000000000000", "000de0b6b3a7640000"),
+                new TxValueBytesPair("1000000000000000001", "000de0b6b3a7640001"),
+                new TxValueBytesPair("1000000000000000000", "000de0b6b3a7640000"),
+                new TxValueBytesPair("1799999999999990000", "0018fae27693b3d8f0"),
+                new TxValueBytesPair("11485000000000000000", "009f62eaa65d5c8000"),
+                new TxValueBytesPair("15940000000000000000", "00dd36418bd7ba0000"),
+                new TxValueBytesPair("15500159000000000000000000", "000cd2494d96e1f8369c0000"),
+                new TxValueBytesPair("15500159777799995555333311", "000cd24958622ef1cffc44bf"),
+                new TxValueBytesPair("77993311779933110000000000", "004083b9e74f854654399c00"),
+                new TxValueBytesPair("77993311779933117799331177", "004083b9e74f85482519f569"));
+
+        for (TxValueBytesPair pair : pairs) {
+            assertBytesValue(pair);
+        }
+    }
+
+    public void assertBytesValue(TxValueBytesPair pair) {
+        // arrange
+        Transaction tx = new Transaction();
+        if ("".equals(pair.input)) {
+            tx.setValue(null);
+        } else {
+            tx.setValue(new BigInteger(pair.input));
+        }
+
+        // act
+        ByteString res = tx.serializeValue();
+        String hexBI = Hex.encodeHexString(res.toByteArray());
+
+        // assert
+        assertEquals(pair.expected, hexBI);
     }
 }

--- a/src/test/java/elrond/TransactionTest.java
+++ b/src/test/java/elrond/TransactionTest.java
@@ -1,12 +1,8 @@
 package elrond;
 
-import com.google.protobuf.ByteString;
-import org.apache.commons.codec.binary.Hex;
 import org.junit.Test;
 
 import java.math.BigInteger;
-import java.util.Arrays;
-import java.util.List;
 
 import static org.junit.Assert.assertEquals;
 


### PR DESCRIPTION
fixed the serialization of the transaction's value. In some cases, the BigInteger method `toByteArray()` returns an additional sign byte, which was already added. Wrote a fix + unit tests that compares the obtained byte array with the ones obtained in the Go version